### PR TITLE
stop copying large array on R-reg

### DIFF
--- a/src/isa/bytecode.rs
+++ b/src/isa/bytecode.rs
@@ -1043,7 +1043,8 @@ impl Bytecode for BitwiseOp {
                     let block = reader.read_u1()?;
                     let reg = reader.read_u3()?;
                     let idx = reader.read_u5()?.into();
-                    let shift2 = u5::with(shift.to_u8() << 1 | sign.into_u8()).into();
+                    let shift2 = u5::with(sign.into_u8() << 4 | shift.to_u8()).into();
+                    println!("shifshif  {:?} {:?}", shift, shift2);
                     match block.into_u8() {
                         0b0 => Self::ShrA(sign.into(), a2, shift.into(), reg.into(), idx),
                         0b1 => Self::ShrR(a2, shift2, reg.into(), idx),

--- a/src/isa/bytecode.rs
+++ b/src/isa/bytecode.rs
@@ -1044,7 +1044,6 @@ impl Bytecode for BitwiseOp {
                     let reg = reader.read_u3()?;
                     let idx = reader.read_u5()?.into();
                     let shift2 = u5::with(sign.into_u8() << 4 | shift.to_u8()).into();
-                    println!("shifshif  {:?} {:?}", shift, shift2);
                     match block.into_u8() {
                         0b0 => Self::ShrA(sign.into(), a2, shift.into(), reg.into(), idx),
                         0b1 => Self::ShrR(a2, shift2, reg.into(), idx),

--- a/src/isa/exec.rs
+++ b/src/isa/exec.rs
@@ -549,7 +549,7 @@ impl InstructionSet for BitwiseOp {
                             RegA2::A8 => regs.a8[shift.to_usize()]? as usize,
                             RegA2::A16 => regs.a16[shift.to_usize()]? as usize,
                         };
-                        let original = regs.get_r(*r, srcdst)?;
+                        let original = regs.get_r_mut(*r, srcdst)?;
                         let n_bytes = r.bytes() as usize;
                         let mut ret = [0u8; 1024];
                         let word_shift = shift / 8;

--- a/src/isa/exec.rs
+++ b/src/isa/exec.rs
@@ -625,6 +625,7 @@ impl InstructionSet for BitwiseOp {
                         RegA2::A8 => regs.a8[shift.to_usize()].unwrap_or_default() as usize,
                         RegA2::A16 => regs.a16[shift.to_usize()].unwrap_or_default() as usize,
                     };
+                    let shift = shift % reg2.bits() as usize;
                     if let Some(original) = regs.get_r_mut(*r, srcdst) {
                         let msb = original.last().copied().unwrap_or_default() & 0x80;
                         let n_bytes = reg2.bytes() as usize;
@@ -639,12 +640,17 @@ impl InstructionSet for BitwiseOp {
                 }
             },
             BitwiseOp::Scr(reg1, shift, reg2, srcdst) => match reg2 {
-                RegAR::A(_) => regs.op(reg2, srcdst, reg1, shift, reg2, srcdst, Number::scr),
+                RegAR::A(_) => {
+                    let lsb = regs.get(reg2, srcdst).unwrap_or_default()[0] & 1;
+                    regs.st0 = lsb == 1;
+                    regs.op(reg2, srcdst, reg1, shift, reg2, srcdst, Number::scr)
+                }
                 RegAR::R(r) => {
                     let shift = match reg1 {
                         RegA2::A8 => regs.a8[shift.to_usize()].unwrap_or_default() as usize,
                         RegA2::A16 => regs.a16[shift.to_usize()].unwrap_or_default() as usize,
                     };
+                    let shift = shift % reg2.bits() as usize;
                     if let Some(original) = regs.get_r_mut(*r, srcdst) {
                         let lsb = original[0] & 1;
                         let n_bytes = reg2.bytes() as usize;

--- a/src/isa/exec.rs
+++ b/src/isa/exec.rs
@@ -572,6 +572,8 @@ impl InstructionSet for BitwiseOp {
             },
             BitwiseOp::ShrA(flag, reg1, shift, reg2, srcdst) => {
                 let res = regs.get_both(reg1, shift, reg2, srcdst).map(|(shift, val)| {
+                    let lsb = val[0] & 1;
+                    regs.st0 = lsb == 1;
                     if *flag == SignFlag::Signed {
                         val.into_signed().shr(shift)
                     } else {

--- a/src/reg/core_regs.rs
+++ b/src/reg/core_regs.rs
@@ -26,6 +26,7 @@ use alloc::string::ToString;
 use alloc::vec::Vec;
 use core::fmt::{self, Debug, Formatter};
 
+use amplify::hex::ToHex;
 use amplify::num::apfloat::ieee;
 use amplify::num::{u1024, u256, u512};
 use half::bf16;
@@ -229,10 +230,10 @@ impl CoreRegs {
                     RegR::R160 => self.r160[index].map(Number::from),
                     RegR::R256 => self.r256[index].map(Number::from),
                     RegR::R512 => self.r512[index].map(Number::from),
-                    RegR::R1024 => self.r1024[index].map(Number::from),
-                    RegR::R2048 => self.r2048[index].map(Number::from),
-                    RegR::R4096 => self.r4096[index].map(Number::from),
-                    RegR::R8192 => self.r8192[index].map(Number::from),
+                    RegR::R1024 => self.r1024[index].as_ref().map(Number::from_slice),
+                    RegR::R2048 => self.r2048[index].as_ref().map(Number::from_slice),
+                    RegR::R4096 => self.r4096[index].as_ref().map(Number::from_slice),
+                    RegR::R8192 => self.r8192[index].as_ref().map(Number::from_slice),
                 };
                 n.into()
             }
@@ -250,6 +251,21 @@ impl CoreRegs {
                 };
                 n.unwrap_or_else(MaybeNumber::none)
             }
+        }
+    }
+
+    /// Retrieves mutable reference to R-register value
+    pub fn get_r(&mut self, reg: impl Into<RegR>, index: impl Into<Reg32>) -> Option<&mut [u8]> {
+        let index = index.into().to_usize();
+        match reg.into() {
+            RegR::R128 => self.r128[index].as_mut().map(|x| x.as_mut_slice()),
+            RegR::R160 => self.r160[index].as_mut().map(|x| x.as_mut_slice()),
+            RegR::R256 => self.r256[index].as_mut().map(|x| x.as_mut_slice()),
+            RegR::R512 => self.r512[index].as_mut().map(|x| x.as_mut_slice()),
+            RegR::R1024 => self.r1024[index].as_mut().map(|x| x.as_mut_slice()),
+            RegR::R2048 => self.r2048[index].as_mut().map(|x| x.as_mut_slice()),
+            RegR::R4096 => self.r4096[index].as_mut().map(|x| x.as_mut_slice()),
+            RegR::R8192 => self.r8192[index].as_mut().map(|x| x.as_mut_slice()),
         }
     }
 
@@ -653,42 +669,66 @@ impl Debug for CoreRegs {
             }
         }
         for i in 0..32 {
-            if let Some(v) = self.r1024[i] {
-                let v = Number::from(v);
+            if let Some(v) = &self.r1024[i] {
                 write!(
                     f,
-                    "{}r1024{}[{}{:02}{}]={}{:X}{}h\n\t\t",
-                    reg, eq, reset, i, eq, val, v, reset
+                    "{}r1024{}[{}{:02}{}]={}{}{}h\n\t\t",
+                    reg,
+                    eq,
+                    reset,
+                    i,
+                    eq,
+                    val,
+                    v.to_hex().to_uppercase(),
+                    reset
                 )?;
             }
         }
         for i in 0..32 {
-            if let Some(v) = self.r2048[i] {
-                let v = Number::from(v);
+            if let Some(v) = &self.r2048[i] {
                 write!(
                     f,
-                    "{}r2048{}[{}{:02}{}]={}{:X}{}h\n\t\t",
-                    reg, eq, reset, i, eq, val, v, reset
+                    "{}r2048{}[{}{:02}{}]={}{}{}h\n\t\t",
+                    reg,
+                    eq,
+                    reset,
+                    i,
+                    eq,
+                    val,
+                    v.to_hex().to_uppercase(),
+                    reset
                 )?;
             }
         }
         for i in 0..32 {
-            if let Some(v) = self.r4096[i] {
-                let v = Number::from(v);
+            if let Some(v) = &self.r4096[i] {
                 write!(
                     f,
-                    "{}r4096{}[{}{:02}{}]={}{:X}{}h\n\t\t",
-                    reg, eq, reset, i, eq, val, v, reset
+                    "{}r4096{}[{}{:02}{}]={}{}{}h\n\t\t",
+                    reg,
+                    eq,
+                    reset,
+                    i,
+                    eq,
+                    val,
+                    v.to_hex().to_uppercase(),
+                    reset
                 )?;
             }
         }
         for i in 0..32 {
-            if let Some(v) = self.r8192[i] {
-                let v = Number::from(v);
+            if let Some(v) = &self.r8192[i] {
                 write!(
                     f,
-                    "{}r8192{}[{}{:02}{}]={}{:X}{}h\n\t\t",
-                    reg, eq, reset, i, eq, val, v, reset
+                    "{}r8192{}[{}{:02}{}]={}{}{}h\n\t\t",
+                    reg,
+                    eq,
+                    reset,
+                    i,
+                    eq,
+                    val,
+                    v.to_hex().to_uppercase(),
+                    reset
                 )?;
             }
         }

--- a/src/reg/core_regs.rs
+++ b/src/reg/core_regs.rs
@@ -230,10 +230,10 @@ impl CoreRegs {
                     RegR::R160 => self.r160[index].map(Number::from),
                     RegR::R256 => self.r256[index].map(Number::from),
                     RegR::R512 => self.r512[index].map(Number::from),
-                    RegR::R1024 => self.r1024[index].as_ref().map(Number::from_slice),
-                    RegR::R2048 => self.r2048[index].as_ref().map(Number::from_slice),
-                    RegR::R4096 => self.r4096[index].as_ref().map(Number::from_slice),
-                    RegR::R8192 => self.r8192[index].as_ref().map(Number::from_slice),
+                    RegR::R1024 => self.r1024[index].map(Number::from),
+                    RegR::R2048 => self.r2048[index].map(Number::from),
+                    RegR::R4096 => self.r4096[index].map(Number::from),
+                    RegR::R8192 => self.r8192[index].map(Number::from),
                 };
                 n.into()
             }
@@ -255,7 +255,11 @@ impl CoreRegs {
     }
 
     /// Retrieves mutable reference to R-register value
-    pub fn get_r(&mut self, reg: impl Into<RegR>, index: impl Into<Reg32>) -> Option<&mut [u8]> {
+    pub fn get_r_mut(
+        &mut self,
+        reg: impl Into<RegR>,
+        index: impl Into<Reg32>,
+    ) -> Option<&mut [u8]> {
         let index = index.into().to_usize();
         match reg.into() {
             RegR::R128 => self.r128[index].as_mut().map(|x| x.as_mut_slice()),


### PR DESCRIPTION
Closes https://github.com/AluVM/rust-aluvm/issues/89

We would overflow the stack by copying large array on R-reg too often. Boxing an array was not the real problem