### PR TITLE
Fix cnv macro (and improviment asm_macro)

### DIFF
--- a/src/isa/bytecode.rs
+++ b/src/isa/bytecode.rs
@@ -515,7 +515,13 @@ impl Bytecode for MoveOp {
                 writer.write_u5(idx2)?;
                 writer.write_u3(reg)?;
             }
-            MoveOp::CpyA(sreg, sidx, dreg, didx) | MoveOp::CnvA(sreg, sidx, dreg, didx) => {
+            MoveOp::CpyA(sreg, sidx, dreg, didx) => {
+                writer.write_u3(sreg)?;
+                writer.write_u5(sidx)?;
+                writer.write_u3(dreg)?;
+                writer.write_u5(didx)?;
+            }
+            MoveOp::CnvA(sreg, sidx, dreg, didx) => {
                 writer.write_u3(sreg)?;
                 writer.write_u5(sidx)?;
                 writer.write_u3(dreg)?;

--- a/src/isa/macros.rs
+++ b/src/isa/macros.rs
@@ -118,12 +118,12 @@ macro_rules! aluasm_inner {
         $code.push($crate::instr!{ $op . $flag $( $arg [ $idx ]  ),+ });
         $crate::aluasm_inner! { $code => $( $tt )* }
     };
-    { $code:ident => $op:ident $arglit:literal, $arg:ident [ $idx:literal ] ; $($tt:tt)* } => {
-        $code.push($crate::instr!{ $op $arglit, $arg [ $idx ] });
+    { $code:ident => $op:ident $arglit:literal, $( $arg:ident [ $idx:literal ] ),+ ; $($tt:tt)* } => {
+        $code.push($crate::instr!{ $op $arglit, $( $arg [ $idx ] ),+ });
         $crate::aluasm_inner! { $code => $( $tt )* }
     };
-    { $code:ident => $op:ident . $flag:ident $arglit:literal, $arg:ident [ $idx:literal ] ; $($tt:tt)* } => {
-        $code.push($crate::instr!{ $op . $flag $arglit, $arg [ $idx ] });
+    { $code:ident => $op:ident . $flag:ident $arglit:literal, $( $arg:ident [ $idx:literal ] ),+ ; $($tt:tt)* } => {
+        $code.push($crate::instr!{ $op . $flag $arglit, $( $arg [ $idx ] ),+ });
         $crate::aluasm_inner! { $code => $( $tt )* }
     };
     { $code:ident => $op:ident $arglit1:literal, $arglit2:literal, $arg:ident [ $idx:literal ] ; $($tt:tt)* } => {
@@ -323,13 +323,13 @@ macro_rules! instr {
             (RegBlockAFR::A, RegBlockAFR::A) => Instr::Move(MoveOp::CnvA(
                 $crate::_reg_tya!(Reg, $src_reg),
                 $crate::_reg_idx!($src_idx),
-                $crate::_reg_tya!(Reg, $src_reg),
+                $crate::_reg_tya!(Reg, $dst_reg),
                 $crate::_reg_idx!($dst_idx),
             )),
             (RegBlockAFR::F, RegBlockAFR::F) => Instr::Move(MoveOp::CnvF(
                 $crate::_reg_tyf!(Reg, $src_reg),
                 $crate::_reg_idx!($src_idx),
-                $crate::_reg_tyf!(Reg, $src_reg),
+                $crate::_reg_tyf!(Reg, $dst_reg),
                 $crate::_reg_idx!($dst_idx),
             )),
             (_, _) => panic!("Conversion operation between unsupported register types"),


### PR DESCRIPTION
**Description**

This PR intent:
- Fix cnv macro destination for arithmetic ops
- Allow instruction with 3 parameters: first a literal and the other two registers.