### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/library/lib.rs
+++ b/src/library/lib.rs
@@ -324,7 +324,9 @@ impl Lib {
         let lib_hash = self.id();
         cursor.seek(entrypoint).ok()?;
 
+        #[cfg(feature = "log")]
         let mut st0 = registers.st0;
+
         while !cursor.is_eof() {
             let pos = cursor.pos();
 
@@ -352,8 +354,9 @@ impl Lib {
                     let c = if registers.st0 { g } else { r };
                     eprint!(" {d}st0={z}{c}{}{z} ", registers.st0);
                 }
+
+                st0 = registers.st0;
             }
-            st0 = registers.st0;
 
             if !registers.acc_complexity(instr) {
                 #[cfg(feature = "log")]


### PR DESCRIPTION
```
warning: variable `st0` is assigned to, but never used
   --> src/library/lib.rs:327:17
    |
327 |         let mut st0 = registers.st0;
    |                 ^^^
    |
    = note: consider using `_st0` instead
    = note: `#[warn(unused_variables)]` on by default

warning: value assigned to `st0` is never read
   --> src/library/lib.rs:356:13
    |
356 |             st0 = registers.st0;
    |             ^^^
    |
    = help: maybe it is overwritten before being read?
    = note: `#[warn(unused_assignments)]` on by default
```